### PR TITLE
chain bottle builds to build-legion workflow

### DIFF
--- a/.github/workflows/build-bottles.yml
+++ b/.github/workflows/build-bottles.yml
@@ -8,6 +8,8 @@ on:
         required: false
         default: false
         type: boolean
+  repository_dispatch:
+    types: [build-bottles]
 
 permissions:
   contents: write
@@ -66,7 +68,7 @@ jobs:
   publish:
     needs: bottle
     runs-on: ubuntu-latest
-    if: inputs.dry_run != true
+    if: inputs.dry_run != true || github.event_name == 'repository_dispatch'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-legion.yml
+++ b/.github/workflows/build-legion.yml
@@ -430,3 +430,14 @@ jobs:
           git push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trigger-bottles:
+    needs: update-formula
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger bottle build
+        run: |
+          gh api repos/LegionIO/homebrew-tap/dispatches \
+            -f event_type=build-bottles
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `repository_dispatch` trigger to `build-bottles.yml` so it can be called from other workflows
- Adds `trigger-bottles` job to `build-legion.yml` that fires after the formula is updated
- Fixes `publish` job condition to always run on `repository_dispatch` (not blocked by missing `dry_run` input)

## Flow after this change
```
build-legion.yml
  → build tarball
  → update-formula (commit new URL/SHA256/version)
  → trigger-bottles (repository_dispatch → build-bottles.yml)
      → bottle on ARM64 Sonoma + Sequoia
      → publish: create release, auto-commit bottle hashes
```

## Test plan
- [ ] Merge
- [ ] Trigger `build-legion.yml` and verify `build-bottles.yml` fires automatically after formula update