### PR TITLE
fix: set explicit chdir in post_install to prevent CWD crash during brew upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Default Python packages expanded: `ruff`, `pylint`, `mypy`, `httpx`, `beautifulsoup4`, `jinja2`
 
 ### Fixed
+- `post_install` CWD crash during `brew upgrade`: old cellar deletion invalidates working directory, causing Thor `Errno::ENOENT` in `reinstall_packs`, `setup_python_venv`, and `background_gem_update` — all now pass `chdir: var/"lib/legion"`
 - `legion-python` and `legion-pip` default venv path changed from `$HOME/.legionio/python` to `libexec/python` (matches actual Cellar install location)
 - `pip install` failures caused by corporate `REQUESTS_CA_BUNDLE` pointing at non-existent `/tmp/system-ca-bundle.pem`
 

--- a/Formula/legionio.rb
+++ b/Formula/legionio.rb
@@ -300,12 +300,15 @@ class Legionio < Formula
       return
     end
 
+    safe_dir = (var/"lib/legion").to_s
+    Dir.mkdir(safe_dir) unless File.directory?(safe_dir)
+
     venv_dir = libexec/"python"
     if venv_dir.exist?
       ohai "Legion Python venv already exists at #{venv_dir}"
     else
       ohai "Creating Legion Python venv at #{venv_dir}"
-      unless system python3, "-m", "venv", venv_dir.to_s
+      unless system(python3, "-m", "venv", venv_dir.to_s, chdir: safe_dir)
         opoo "Failed to create Python venv — run 'legionio setup python' manually"
         return
       end
@@ -318,7 +321,7 @@ class Legionio < Formula
     end
 
     ohai "Installing Python packages: #{PYTHON_PACKAGES.join(', ')}"
-    unless system pip.to_s, "install", "--quiet", "--upgrade", *PYTHON_PACKAGES
+    unless system(pip.to_s, "install", "--quiet", "--upgrade", *PYTHON_PACKAGES, chdir: safe_dir)
       opoo "Some Python packages failed — run 'legionio setup python' to retry"
     end
 
@@ -344,9 +347,12 @@ class Legionio < Formula
     packs = discover_installed_packs
     return if packs.empty?
 
+    safe_dir = (var/"lib/legion").to_s
+    Dir.mkdir(safe_dir) unless File.directory?(safe_dir)
+
     packs.each do |pack|
       ohai "Reinstalling #{pack} pack after upgrade"
-      unless system bin/"legionio", "setup", pack
+      unless system(bin/"legionio", "setup", pack, chdir: safe_dir)
         opoo "Pack '#{pack}' reinstall failed — run 'legionio setup #{pack}' manually after upgrade"
       end
     end
@@ -376,9 +382,12 @@ class Legionio < Formula
   def background_gem_update
     ohai "Updating legion gems in background"
     log_file = var/"log/legion/post-upgrade-update.log"
+    safe_dir = (var/"lib/legion").to_s
+    Dir.mkdir(safe_dir) unless File.directory?(safe_dir)
     pid = spawn(
       (bin/"legionio").to_s, "update",
       [:out, :err] => [log_file.to_s, "w"],
+      chdir: safe_dir,
       pgroup: true
     )
     ::Process.detach(pid)


### PR DESCRIPTION
## Summary
- Add `chdir: var/"lib/legion"` to all `system`/`spawn` calls in `post_install` helpers (`reinstall_packs`, `setup_python_venv`, `background_gem_update`)

## Why
During `brew upgrade`, the old cellar (`/opt/homebrew/Cellar/legionio/<old-version>`) is deleted before `post_install` runs. The shell's CWD becomes invalid, and Thor crashes with `Errno::ENOENT` on `File.expand_path` in `register_klass_file`. This causes:
- Pack reinstallation to silently fail (no extensions restored after upgrade)
- Python venv creation to fail ("Failed to create Python venv")
- Background gem update to crash (`getcwd: cannot access parent directories`)

Evidence from `/opt/homebrew/var/log/legion/post-upgrade-update.log`:
```
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
thor/base.rb:149:in 'File.expand_path': No such file or directory - getcwd (Errno::ENOENT)
```

## Fix
Use the same directory the service block already declares as `working_dir` — `var/"lib/legion"` — as the explicit `chdir:` for all post_install subprocess invocations.

## Test plan
- [ ] `brew upgrade legionio` completes with packs reinstalled (check for "Reinstalling X pack" output)
- [ ] Python venv created successfully (no "Failed to create Python venv" warning)
- [ ] `cat /opt/homebrew/var/log/legion/post-upgrade-update.log` shows successful `legionio update` output, not a stack trace