### PR TITLE
fix: revert venv to ~/.legionio/python + Dir.chdir in post_install

### DIFF
--- a/Formula/legionio.rb
+++ b/Formula/legionio.rb
@@ -1,18 +1,20 @@
 class Legionio < Formula
   desc "LegionIO async job engine, agentic AI daemon, and interactive shell"
   homepage "https://github.com/LegionIO/LegionIO"
-  version "1.9.39-3"
+  version "1.9.39-4"
   license "Apache-2.0"
 
   on_arm do
-    url "https://github.com/LegionIO/homebrew-tap/releases/download/legion-1.9.39-3/legion-1.9.39-3-darwin-arm64.tar.gz"
-    sha256 "02ff393ef0570946917836a6ec48da16611d8fcdfca44223e2109a3517706333"
+    url "https://github.com/LegionIO/homebrew-tap/releases/download/legion-1.9.39-4/legion-1.9.39-4-darwin-arm64.tar.gz"
+    sha256 "25cee0a35ad7426b7544119c38be5c3c5f7016db1b064a7425e7891c20dba905"
   end
 
   on_intel do
-    url "https://github.com/LegionIO/homebrew-tap/releases/download/legion-1.9.39-3/legion-1.9.39-3-darwin-x86_64.tar.gz"
-    sha256 "370f84ac12fa3831b9cffc012f03327c62184f9d6490dfcb478c35e739df94f4"
+    url "https://github.com/LegionIO/homebrew-tap/releases/download/legion-1.9.39-4/legion-1.9.39-4-darwin-x86_64.tar.gz"
+    sha256 "edb36e72a5c854c1cef95cd12a6c726a17d78173cf1ed569478640433cd15890"
   end
+
+
 
 
 
@@ -26,10 +28,10 @@ class Legionio < Formula
 
 
   bottle do
-    root_url "https://github.com/LegionIO/homebrew-tap/releases/download/bottles-legionio-1.9.39-3"
-    sha256 cellar: :any, arm64_sequoia: "e79382750dceb53e02ba6d187050c93156360a7e9d97ccbdf0afbfe02f402322"
-    sha256 cellar: :any, arm64_sonoma: "6a751cca1b31dab41ece762d7d06c5d8bce1458305a4f41f4c82390eed870677"
-    sha256 cellar: :any, sequoia: "75aec552f763a3a3ae96b6a90028bf01ceb06c32564f4e31e4498745a172e816"
+    root_url "https://github.com/LegionIO/homebrew-tap/releases/download/bottles-legionio-1.9.39-4"
+    sha256 cellar: :any, arm64_sequoia: "cfbbab58bc6bf84a8c422b0d27ea9b23d55300327a63fbd8b608841c8803ac57"
+    sha256 cellar: :any, arm64_sonoma: "fa13144afe07eac27393425f2cc67320c530173dec9a33f6d55c764d59f2482b"
+    sha256 cellar: :any, sequoia: "e39525167f84166276cb2df205cfa78dde7cd9750df8e1a255774d6b74afe607"
   end
 
   depends_on "krb5"
@@ -100,8 +102,8 @@ class Legionio < Formula
       export BUNDLE_GEMFILE=""
       export RUBYOPT=""
       export GEM_SPEC_CACHE="#{gem_dir}/spec_cache"
-      export LEGION_PYTHON_VENV="#{libexec}/python"
-      export LEGION_PYTHON="#{libexec}/python/bin/python3"
+      export LEGION_PYTHON_VENV="${HOME}/.legionio/python"
+      export LEGION_PYTHON="${HOME}/.legionio/python/bin/python3"
       export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
       export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
       export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
@@ -124,8 +126,8 @@ class Legionio < Formula
       export BUNDLE_GEMFILE=""
       export RUBYOPT=""
       export GEM_SPEC_CACHE="#{gem_dir}/spec_cache"
-      export LEGION_PYTHON_VENV="#{libexec}/python"
-      export LEGION_PYTHON="#{libexec}/python/bin/python3"
+      export LEGION_PYTHON_VENV="${HOME}/.legionio/python"
+      export LEGION_PYTHON="${HOME}/.legionio/python/bin/python3"
       export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
       export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
       export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
@@ -162,7 +164,7 @@ class Legionio < Formula
       export PYTHONPATH=""
       export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
       unset PYTHONHOME
-      VENV="${LEGION_PYTHON_VENV:-#{libexec}/python}"
+      VENV="${LEGION_PYTHON_VENV:-${HOME}/.legionio/python}"
       if [ -x "${VENV}/bin/python3" ]; then
         exec "${VENV}/bin/python3" "$@"
       else
@@ -180,7 +182,7 @@ class Legionio < Formula
       export PYTHONPATH=""
       export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
       unset PYTHONHOME
-      VENV="${LEGION_PYTHON_VENV:-#{libexec}/python}"
+      VENV="${LEGION_PYTHON_VENV:-${HOME}/.legionio/python}"
       if [ -x "${VENV}/bin/pip3" ]; then
         exec "${VENV}/bin/pip3" "$@"
       else
@@ -204,22 +206,22 @@ class Legionio < Formula
     working_dir var/"lib/legion"
     log_path var/"log/legion/legion.log"
     error_log_path var/"log/legion/legion.log"
-    environment_variables LANG:              "en_US.UTF-8",
-                          LC_ALL:            "en_US.UTF-8",
-                          GEM_PATH:          "#{libexec}/lib/ruby/gems/3.4.0",
-                          GEM_HOME:          "#{libexec}/lib/ruby/gems/3.4.0",
-                          GEM_SPEC_CACHE:    "#{libexec}/lib/ruby/gems/3.4.0/spec_cache",
-                          RUBYGEMS_GEMDEPS:  "",
-                          BUNDLE_GEMFILE:    "",
-                          RUBYOPT:           "",
-                          LEGION_PYTHON_VENV: "#{libexec}/python",
-                          LEGION_PYTHON:     "#{libexec}/python/bin/python3",
-                          SSL_CERT_FILE:     "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem",
+    environment_variables LANG:               "en_US.UTF-8",
+                          LC_ALL:             "en_US.UTF-8",
+                          GEM_PATH:           "#{libexec}/lib/ruby/gems/3.4.0",
+                          GEM_HOME:           "#{libexec}/lib/ruby/gems/3.4.0",
+                          GEM_SPEC_CACHE:     "#{libexec}/lib/ruby/gems/3.4.0/spec_cache",
+                          RUBYGEMS_GEMDEPS:   "",
+                          BUNDLE_GEMFILE:     "",
+                          RUBYOPT:            "",
+                          SSL_CERT_FILE:      "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem",
                           REQUESTS_CA_BUNDLE: "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem",
-                          CURL_CA_BUNDLE:    "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+                          CURL_CA_BUNDLE:     "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
   end
 
   def post_install
+    (var/"lib/legion").mkpath
+    Dir.chdir(var/"lib/legion")
     install_tls_certificates
     reinstall_packs
     setup_python_venv
@@ -300,15 +302,12 @@ class Legionio < Formula
       return
     end
 
-    safe_dir = (var/"lib/legion").to_s
-    Dir.mkdir(safe_dir) unless File.directory?(safe_dir)
-
-    venv_dir = libexec/"python"
+    venv_dir = Pathname.new(File.expand_path("~/.legionio/python"))
     if venv_dir.exist?
       ohai "Legion Python venv already exists at #{venv_dir}"
     else
       ohai "Creating Legion Python venv at #{venv_dir}"
-      unless system(python3, "-m", "venv", venv_dir.to_s, chdir: safe_dir)
+      unless system python3, "-m", "venv", venv_dir.to_s
         opoo "Failed to create Python venv — run 'legionio setup python' manually"
         return
       end
@@ -321,7 +320,7 @@ class Legionio < Formula
     end
 
     ohai "Installing Python packages: #{PYTHON_PACKAGES.join(', ')}"
-    unless system(pip.to_s, "install", "--quiet", "--upgrade", *PYTHON_PACKAGES, chdir: safe_dir)
+    unless system pip.to_s, "install", "--quiet", "--upgrade", *PYTHON_PACKAGES
       opoo "Some Python packages failed — run 'legionio setup python' to retry"
     end
 
@@ -347,12 +346,9 @@ class Legionio < Formula
     packs = discover_installed_packs
     return if packs.empty?
 
-    safe_dir = (var/"lib/legion").to_s
-    Dir.mkdir(safe_dir) unless File.directory?(safe_dir)
-
     packs.each do |pack|
       ohai "Reinstalling #{pack} pack after upgrade"
-      unless system(bin/"legionio", "setup", pack, chdir: safe_dir)
+      unless system bin/"legionio", "setup", pack
         opoo "Pack '#{pack}' reinstall failed — run 'legionio setup #{pack}' manually after upgrade"
       end
     end
@@ -382,12 +378,9 @@ class Legionio < Formula
   def background_gem_update
     ohai "Updating legion gems in background"
     log_file = var/"log/legion/post-upgrade-update.log"
-    safe_dir = (var/"lib/legion").to_s
-    Dir.mkdir(safe_dir) unless File.directory?(safe_dir)
     pid = spawn(
       (bin/"legionio").to_s, "update",
       [:out, :err] => [log_file.to_s, "w"],
-      chdir: safe_dir,
       pgroup: true
     )
     ::Process.detach(pid)


### PR DESCRIPTION
## Problem

Two chained failures after PR #28 + PR #29:

1. **Venv in cellar** — PR #28 moved the Python venv from `~/.legionio/python` into `libexec/python`. On `brew upgrade`, the old cellar is deleted which invalidates CWD for any `post_install` subprocess.
2. **Thor ENOENT crash** — `background_gem_update` spawned `legionio update` into a deleted cellar directory. Thor dies at import time (`File.expand_path` → `Errno::ENOENT`) before any pack reinstall can run.

The `post-upgrade-update.log` from 1.9.39-2 confirms this exact crash.

## Fix

- **Revert venv** back to `~/.legionio/python` — survives upgrades, no cellar lifecycle issues
- **Single `Dir.chdir(var/"lib/legion")`** at top of `post_install` — sets CWD once for all children, eliminates per-call `chdir:` boilerplate
- **Updated wrappers** (legionio, legion, legion-python, legion-pip) and service block to use `~/.legionio/python`
- **Preserved** TLS cert isolation, `PYTHONPATH=""`, `unset PYTHONHOME` from PR #28