### PR TITLE
Fix deprecated macos depends_on syntax in legion-interlink cask

### DIFF
--- a/Casks/legion-interlink.rb
+++ b/Casks/legion-interlink.rb
@@ -11,7 +11,7 @@ cask "legion-interlink" do
   depends_on formula: "redis"
   depends_on formula: "memcached"
   depends_on formula: "ollama"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Legion Interlink.app"
 


### PR DESCRIPTION
Fixes the deprecation warning when installing legion-interlink via Homebrew.

The deprecated string comparison format `depends_on macos: ">= :ventura"` has been replaced with the modern Homebrew syntax `depends_on macos: :ventura`.

This resolves the warning:
```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :ventura` instead.
```