### PR TITLE
Fix deprecated macOS dependency syntax in legion-interlink cask

### DIFF
--- a/Casks/legion-interlink.rb
+++ b/Casks/legion-interlink.rb
@@ -11,7 +11,7 @@ cask "legion-interlink" do
   depends_on formula: "redis"
   depends_on formula: "memcached"
   depends_on formula: "ollama"
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Legion Interlink.app"
 


### PR DESCRIPTION
Fix deprecated Homebrew warning:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :ventura` instead.
```

**Change:** `depends_on macos: ">= :ventura"` → `depends_on macos: :ventura`

The symbol form is semantically equivalent (means "Ventura or newer") and is the current Homebrew API.