### PR TITLE
Fix internal VIP TLS: merge OS trust-store CAs over public bundle

### DIFF
--- a/Formula/legionio.rb
+++ b/Formula/legionio.rb
@@ -507,24 +507,43 @@ class Legionio < Formula
   # CA is present in the OS trust store.
   #
   # The bundle is therefore: current OS trust-store certificates first (they
-  # win), then the public bundle minus same-subject shadows.
+  # win), then the public bundle minus exact (subject + key) duplicates.
+  #
+  # Notes on behavior, kept deliberate:
+  # - The OS set is kept verbatim, including both generations of any
+  #   reissued same-subject CA. The stale OS copy remains in the final
+  #   bundle; verification works because the live key is present alongside
+  #   it, not because the stale copy was removed. Do not add subject dedup
+  #   to the OS set — that would re-introduce the bug.
+  # - A public cert is dropped only when an OS cert has the same subject
+  #   AND the same public key, so a live cert that exists only in the
+  #   public bundle can never be discarded.
+  # - The merged file is ALWAYS written (OS-trust-only if the public
+  #   bundle is missing). The bin shims point SSL_CERT_FILE at it
+  #   unconditionally, so a missing file would break all TLS, including
+  #   public hosts — a harder failure than the shadowing this fixes.
   def rebuild_merged_bundle(cert_dir)
     openssl = Formula["openssl@3"].opt_bin/"openssl"
     public_bundle = HOMEBREW_PREFIX/"etc/openssl@3/cert.pem"
     merged = HOMEBREW_PREFIX/"etc/openssl@3/legionio-cert.pem"
-    return unless public_bundle.exist?
 
     require "tmpdir"
+    require "digest"
     pem = /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
     Dir.mktmpdir("legionio-merged-ca") do |dir|
       d = Pathname(dir)
       n = 0
 
-      subject_of = lambda do |cert|
+      # Dedup key: subject DN + SHA256 of the public key (SPKI material).
+      # Empty subject (unreadable cert) yields a key that can never match.
+      key_of = lambda do |cert|
         cf = d/"c-#{n}.pem"
         n += 1
         cf.write(cert)
-        `#{openssl} x509 -in "#{cf}" -noout -subject -nameopt oneline 2>/dev/null`.strip
+        subject = `#{openssl} x509 -in "#{cf}" -noout -subject -nameopt oneline 2>/dev/null`.strip
+        pubkey = `#{openssl} x509 -in "#{cf}" -noout -pubkey 2>/dev/null`
+        key = subject.empty? ? "" : subject + "|" + Digest::SHA256.hexdigest(pubkey)
+        key
       end
 
       # 1) Current OS trust-store certs (JAMF/MDM-managed corporate PKI).
@@ -532,24 +551,26 @@ class Legionio < Formula
                            .select { |f| File.exist?(f) }
                            .flat_map { |f| File.read(f).scan(pem) }
       os_certs.uniq!
-      os_subjects = os_certs.filter_map { |c| (s = subject_of.(c)).empty? ? nil : s }
+      os_keys = os_certs.filter_map { |c| (k = key_of.(c)).empty? ? nil : k }
 
-      # 2) Public bundle, minus same-subject shadows of the certs above.
+      # 2) Public bundle, minus exact (subject + key) duplicates above.
       kept = 0
       dropped = 0
       out = +""
-      File.read(public_bundle).scan(pem).uniq.each do |cert|
-        s = subject_of.(cert)
-        if s.empty? || os_subjects.include?(s)
-          dropped += 1
-        else
-          out << cert << "\n"
-          kept += 1
+      if public_bundle.exist?
+        File.read(public_bundle).scan(pem).uniq.each do |cert|
+          k = key_of.(cert)
+          if k.empty? || os_keys.include?(k)
+            dropped += 1
+          else
+            out << cert << "\n"
+            kept += 1
+          end
         end
       end
 
-      merged.atomic_write(os_certs.join("\n") + "\n" + out)
-      ohai "Trust bundle #{merged.basename}: #{os_certs.size} system CA(s), #{kept} public CA(s), #{dropped} shadowed duplicate(s) removed"
+      merged.atomic_write(os_certs.join("\n") + (os_certs.empty? ? "" : "\n") + out)
+      ohai "Trust bundle #{merged.basename}: #{os_certs.size} system CA(s), #{kept} public CA(s), #{dropped} duplicate(s) removed"
     end
   end
 

--- a/Formula/legionio.rb
+++ b/Formula/legionio.rb
@@ -89,11 +89,11 @@ class Legionio < Formula
       export GEM_SPEC_CACHE="#{gem_dir}/spec_cache"
       export LEGION_PYTHON_VENV="#{libexec}/python"
       export LEGION_PYTHON="#{libexec}/python/bin/python3"
-      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       export PYTHONPATH=""
-      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       unset PYTHONHOME
       exec "#{libexec}/bin/ruby" "#{libexec}/bin/legionio" "$@"
     BASH
@@ -113,11 +113,11 @@ class Legionio < Formula
       export GEM_SPEC_CACHE="#{gem_dir}/spec_cache"
       export LEGION_PYTHON_VENV="#{libexec}/python"
       export LEGION_PYTHON="#{libexec}/python/bin/python3"
-      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       export PYTHONPATH=""
-      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       unset PYTHONHOME
       exec "#{libexec}/bin/ruby" "#{libexec}/bin/legion" "$@"
     BASH
@@ -143,11 +143,11 @@ class Legionio < Formula
     # Python venv helpers — use the Legion-managed venv interpreter/pip
     (bin/"legion-python").write <<~BASH
       #!/bin/bash
-      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       export PYTHONPATH=""
-      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       unset PYTHONHOME
       VENV="${LEGION_PYTHON_VENV:-#{libexec}/python}"
       if [ -x "${VENV}/bin/python3" ]; then
@@ -161,11 +161,11 @@ class Legionio < Formula
 
     (bin/"legion-pip").write <<~BASH
       #!/bin/bash
-      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
-      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export SSL_CERT_FILE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export REQUESTS_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
+      export CURL_CA_BUNDLE="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       export PYTHONPATH=""
-      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+      export PIP_CERT="#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
       unset PYTHONHOME
       VENV="${LEGION_PYTHON_VENV:-#{libexec}/python}"
       if [ -x "${VENV}/bin/pip3" ]; then
@@ -199,9 +199,9 @@ class Legionio < Formula
                           RUBYGEMS_GEMDEPS:   "",
                           BUNDLE_GEMFILE:     "",
                           RUBYOPT:            "",
-                          SSL_CERT_FILE:      "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem",
-                          REQUESTS_CA_BUNDLE: "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem",
-                          CURL_CA_BUNDLE:     "#{HOMEBREW_PREFIX}/etc/openssl@3/cert.pem"
+                          SSL_CERT_FILE:      "#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem",
+                          REQUESTS_CA_BUNDLE: "#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem",
+                          CURL_CA_BUNDLE:     "#{HOMEBREW_PREFIX}/etc/openssl@3/legionio-cert.pem"
   end
 
   # Homebrew sandbox overrides $HOME during post_install.  Use Etc.getpwuid(Process.uid).dir
@@ -478,6 +478,78 @@ class Legionio < Formula
     if needs_rehash
       ohai "Rehashing certificate directory"
       system c_rehash.to_s, cert_dir.to_s
+    end
+
+    rebuild_merged_bundle(cert_dir)
+  end
+
+  # Certificate files imported from the OS trust store (macOS keychains or
+  # the Linux system bundle) by install_tls_certificates.
+  def os_trust_cert_files(cert_dir)
+    if OS.mac?
+      Dir["#{cert_dir}/system-*.pem",
+          "#{cert_dir}/systemrootcertificates-*.pem",
+          "#{cert_dir}/login.keychain-db-*.pem"]
+    else
+      ["#{cert_dir}/system-ca-bundle.pem"]
+    end
+  end
+
+  # Build the merged trust bundle that all legion processes use via
+  # SSL_CERT_FILE/REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE/PIP_CERT.
+  #
+  # homebrew-core's ca-certificates builds cert.pem on a CI machine and,
+  # on macOS, merges that machine's keychain into the bottle. A corporate CA
+  # from there can be a stale generation of a certificate whose subject DN
+  # matches the current one. OpenSSL's by-subject chain lookup then finds
+  # the stale key first and verification of internal VIPs that serve leaf
+  # only fails ("unable to get issuer certificate") even though the current
+  # CA is present in the OS trust store.
+  #
+  # The bundle is therefore: current OS trust-store certificates first (they
+  # win), then the public bundle minus same-subject shadows.
+  def rebuild_merged_bundle(cert_dir)
+    openssl = Formula["openssl@3"].opt_bin/"openssl"
+    public_bundle = HOMEBREW_PREFIX/"etc/openssl@3/cert.pem"
+    merged = HOMEBREW_PREFIX/"etc/openssl@3/legionio-cert.pem"
+    return unless public_bundle.exist?
+
+    require "tmpdir"
+    pem = /-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----/m
+    Dir.mktmpdir("legionio-merged-ca") do |dir|
+      d = Pathname(dir)
+      n = 0
+
+      subject_of = lambda do |cert|
+        cf = d/"c-#{n}.pem"
+        n += 1
+        cf.write(cert)
+        `#{openssl} x509 -in "#{cf}" -noout -subject -nameopt oneline 2>/dev/null`.strip
+      end
+
+      # 1) Current OS trust-store certs (JAMF/MDM-managed corporate PKI).
+      os_certs = os_trust_cert_files(cert_dir)
+                           .select { |f| File.exist?(f) }
+                           .flat_map { |f| File.read(f).scan(pem) }
+      os_certs.uniq!
+      os_subjects = os_certs.filter_map { |c| (s = subject_of.(c)).empty? ? nil : s }
+
+      # 2) Public bundle, minus same-subject shadows of the certs above.
+      kept = 0
+      dropped = 0
+      out = +""
+      File.read(public_bundle).scan(pem).uniq.each do |cert|
+        s = subject_of.(cert)
+        if s.empty? || os_subjects.include?(s)
+          dropped += 1
+        else
+          out << cert << "\n"
+          kept += 1
+        end
+      end
+
+      merged.atomic_write(os_certs.join("\n") + "\n" + out)
+      ohai "Trust bundle #{merged.basename}: #{os_certs.size} system CA(s), #{kept} public CA(s), #{dropped} shadowed duplicate(s) removed"
     end
   end
 


### PR DESCRIPTION
## Problem

`brew install legionio` on macOS sets `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`/`PIP_CERT` to `etc/openssl@3/cert.pem` (the homebrew-core `ca-certificates` bottle). That formula **bakes the bottle build machine's macOS keychain into the bundle at build time**. On our internal build farm that means an old generation of the corporate policy CA (same subject DN, different key) is shipped to every laptop.

Consequence: OpenSSL's by-subject chain lookup finds the stale key first, and verification of leaf-only internal VIPs (e.g. `tfe-arc.uhg.com`, `vault-test.uhg.com`) fails with `unable to get issuer certificate` — even though the current CA **is** present in the local OS trust store and was already synced to `etc/openssl@3/certs` by this formula's existing keychain import. Every Ruby/Python process launched by legionio was affected (all lex extensions' Faraday/Net::HTTP clients).

## Fix

In `install_tls_certificates`, after the existing keychain import, build a legionio-managed merged bundle at `etc/openssl@3/legionio-cert.pem`:

1. Current OS trust-store certificates first (macOS: System + SystemRoot + login keychains; Linux: system bundle) — they win
2. Public `cert.pem` minus exact duplicates (same subject **and** same public key), so a same-name/different-key cert is never discarded from either side

Point all SSL env vars (bin shims + service) at the merged bundle. No certificates ship in the repo; the local keychain stays the source of truth.

Deliberate behaviors (documented in the method):

- **The OS set is kept verbatim**, including both generations of a reissued same-subject CA. The stale OS-side copy remains in the bundle; verification works because the **live key is present alongside it**, not because the shadow was removed. Do not add subject dedup to the OS set — that re-introduces the bug.
- **The bundle is always written.** `rebuild_merged_bundle` runs unconditionally from `post_install` (outside the 30-day `cert_fresh?` gate, so upgrades rebuild too), and falls back to the OS-trust set alone if the public bundle is missing — the shims point `SSL_CERT_FILE` at it unconditionally, so a missing file must never be reachable.
- **Security note:** the merged bundle prefers the OS-trust copy of public roots (171 of 203 public certs are same-key duplicates of keychain certs and dropped). If a root were distrusted upstream in a Mozilla CA update but lingered in the local keychain, legionio would keep trusting it until the keychain is refreshed. Low risk; flagging it.
- The per-host `s_client` chain fetches (rubygems/github/legionio) are now inert (their `*.pem` files aren't in the merged bundle and `SSL_CERT_DIR` isn't exported). Left in place for this PR to keep the diff focused; candidate for removal or fold-in later.

## Verification

Ran the formula's exact method on a workstation, then real Ruby (`SSL_CERT_FILE` = merged bundle, `SSL_CERT_DIR` disabled) against:

- `tfe-arc.uhg.com` → TLS OK, HTTP 401 (auth, not TLS)
- `vault-test.uhg.com` → TLS OK, HTTP 200
- `api.github.com` → 200, `rubygems.org` → 200 (public CAs unaffected)

Bundle contents: 205 OS trust-store CAs, 31 public CAs, 172 exact duplicates removed; `OptumInternalIssuingCA2` (the actual leaf issuer) present.